### PR TITLE
new correct syntax for express-handlebars is added

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,27 +1,33 @@
-const express = require('express');
-const bodyParser = require('body-parser');
-const exphbs = require('express-handlebars');
-const path = require('path');
-const nodemailer = require('nodemailer');
+const express = require("express");
+const bodyParser = require("body-parser");
+const expressHbs = require("express-handlebars");
+const path = require("path");
+const nodemailer = require("nodemailer");
 
 const app = express();
-
 // View engine setup
-app.engine('handlebars', exphbs());
-app.set('view engine', 'handlebars');
+app.engine(
+  "handlebars",
+  expressHbs.engine({
+    layoutsDir: "views/",
+    defaultLayout: null,
+    extname: "handlebars",
+  })
+);
+app.set("view engine", "handlebars");
 
 // Static folder
-app.use('/public', express.static(path.join(__dirname, 'public')));
+app.use("/public", express.static(path.join(__dirname, "public")));
 
 // Body Parser Middleware
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 
-app.get('/', (req, res) => {
-  res.render('contact');
+app.get("/", (req, res) => {
+  res.render("contact");
 });
 
-app.post('/send', (req, res) => {
+app.post("/send", (req, res) => {
   const output = `
     <p>You have a new contact request</p>
     <h3>Contact Details</h3>
@@ -37,37 +43,37 @@ app.post('/send', (req, res) => {
 
   // create reusable transporter object using the default SMTP transport
   let transporter = nodemailer.createTransport({
-    host: 'mail.YOURDOMAIN.com',
+    host: "mail.YOURDOMAIN.com",
     port: 587,
     secure: false, // true for 465, false for other ports
     auth: {
-        user: 'YOUREMAIL', // generated ethereal user
-        pass: 'YOURPASSWORD'  // generated ethereal password
+      user: "YOUREMAIL", // generated ethereal user
+      pass: "YOURPASSWORD", // generated ethereal password
     },
-    tls:{
-      rejectUnauthorized:false
-    }
+    tls: {
+      rejectUnauthorized: false,
+    },
   });
 
   // setup email data with unicode symbols
   let mailOptions = {
-      from: '"Nodemailer Contact" <your@email.com>', // sender address
-      to: 'RECEIVEREMAILS', // list of receivers
-      subject: 'Node Contact Request', // Subject line
-      text: 'Hello world?', // plain text body
-      html: output // html body
+    from: '"Nodemailer Contact" <your@email.com>', // sender address
+    to: "RECEIVEREMAILS", // list of receivers
+    subject: "Node Contact Request", // Subject line
+    text: "Hello world?", // plain text body
+    html: output, // html body
   };
 
   // send mail with defined transport object
   transporter.sendMail(mailOptions, (error, info) => {
-      if (error) {
-          return console.log(error);
-      }
-      console.log('Message sent: %s', info.messageId);   
-      console.log('Preview URL: %s', nodemailer.getTestMessageUrl(info));
+    if (error) {
+      return console.log(error);
+    }
+    console.log("Message sent: %s", info.messageId);
+    console.log("Preview URL: %s", nodemailer.getTestMessageUrl(info));
 
-      res.render('contact', {msg:'Email has been sent'});
+    res.render("contact", { msg: "Email has been sent" });
   });
-  });
+});
 
-app.listen(3000, () => console.log('Server started...'));
+app.listen(3000, () => console.log("Server started..."));

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   "author": "Brad Traversy",
   "license": "MIT",
   "dependencies": {
-    "body-parser": "^1.17.2",
-    "express": "^4.15.4",
-    "express-handlebars": "^3.0.0",
-    "nodemailer": "^4.1.0"
+    "body-parser": "^1.20.0",
+    "express": "^4.18.1",
+    "express-handlebars": "^6.0.6",
+    "nodemailer": "^6.7.7",
+    "nodemon": "^2.0.19"
   }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,106 +1,112 @@
-*{
+* {
   box-sizing: border-box;
 }
 
-body{
-  background:#92bde7;
-  color:#485e74;
-  line-height:1.6;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  padding:1em;
-}
-
-.container{
-  max-width:1170px;
-  margin-left:auto;
-  margin-right:auto;
-  padding:1em;
-}
-
-ul{
-  list-style: none;
-  padding:0;
-}
-
-.brand{
-  text-align: center;
-}
-
-.brand span{
-  color:#fff;
-}
-
-.wrapper{
-  box-shadow: 0 0 20px 0 rgba(72,94,116,0.7);
-}
-
-.wrapper > *{
+body {
+  background: #92bde7;
+  color: #485e74;
+  line-height: 1.6;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   padding: 1em;
 }
 
-.company-info{
-  background:#c9e6ff;
+.container {
+  max-width: 1170px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 1em;
 }
 
-.company-info h3, .company-info ul{
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+.brand {
   text-align: center;
-  margin:0 0 1rem 0;
 }
 
-.contact{
-  background:#f9feff;
+.brand span {
+  color: #fff;
+}
+
+.wrapper {
+  box-shadow: 0 0 20px 0 rgba(72, 94, 116, 0.7);
+}
+
+.wrapper > * {
+  padding: 1em;
+}
+
+.company-info {
+  background: #c9e6ff;
+}
+
+.company-info h3,
+.company-info ul {
+  text-align: center;
+  margin: 0 0 1rem 0;
+}
+
+.contact {
+  background: #f9feff;
 }
 
 /* FORM STYLES */
-.contact form{
+.contact form {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-gap:20px;
+  grid-gap: 20px;
 }
 
-.contact form label{
-  display:block;
+.contact form label {
+  display: block;
 }
 
-.contact form p{
-  margin:0;
+.contact form p {
+  margin: 0;
 }
 
-.contact form .full{
+.contact form .full {
   grid-column: 1 / 3;
 }
 
-.contact form button, .contact form input, .contact form textarea{
-  width:100%;
-  padding:1em;
-  border:1px solid #c9e6ff;
+.contact form button,
+.contact form input,
+.contact form textarea {
+  width: 100%;
+  padding: 1em;
+  border: 1px solid #c9e6ff;
 }
 
-.contact form button{
-  background:#c9e6ff;
-  border:0;
+.contact form button {
+  background: #c9e6ff;
+  border: 0;
   text-transform: uppercase;
 }
 
-.contact form button:hover,.contact form button:focus{
-  background:#92bde7;
-  color:#fff;
-  outline:0;
+.contact form button:hover,
+.contact form button:focus {
+  background: #92bde7;
+  color: #fff;
+  outline: 0;
   transition: background-color 2s ease-out;
 }
 
 /* LARGE SCREENS */
-@media(min-width:700px){
-  .wrapper{
+@media (min-width: 700px) {
+  .wrapper {
     display: grid;
     grid-template-columns: 1fr 2fr;
   }
 
-  .wrapper > *{
-    padding:2em;
+  .wrapper > * {
+    padding: 2em;
   }
 
-  .company-info h3, .company-info ul, .brand{
+  .company-info h3,
+  .company-info ul,
+  .brand {
     text-align: left;
   }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,112 +1,106 @@
-* {
+*{
   box-sizing: border-box;
 }
 
-body {
-  background: #92bde7;
-  color: #485e74;
-  line-height: 1.6;
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  padding: 1em;
+body{
+  background:#92bde7;
+  color:#485e74;
+  line-height:1.6;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  padding:1em;
 }
 
-.container {
-  max-width: 1170px;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 1em;
+.container{
+  max-width:1170px;
+  margin-left:auto;
+  margin-right:auto;
+  padding:1em;
 }
 
-ul {
+ul{
   list-style: none;
-  padding: 0;
+  padding:0;
 }
 
-.brand {
+.brand{
   text-align: center;
 }
 
-.brand span {
-  color: #fff;
+.brand span{
+  color:#fff;
 }
 
-.wrapper {
-  box-shadow: 0 0 20px 0 rgba(72, 94, 116, 0.7);
+.wrapper{
+  box-shadow: 0 0 20px 0 rgba(72,94,116,0.7);
 }
 
-.wrapper > * {
+.wrapper > *{
   padding: 1em;
 }
 
-.company-info {
-  background: #c9e6ff;
+.company-info{
+  background:#c9e6ff;
 }
 
-.company-info h3,
-.company-info ul {
+.company-info h3, .company-info ul{
   text-align: center;
-  margin: 0 0 1rem 0;
+  margin:0 0 1rem 0;
 }
 
-.contact {
-  background: #f9feff;
+.contact{
+  background:#f9feff;
 }
 
 /* FORM STYLES */
-.contact form {
+.contact form{
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-gap: 20px;
+  grid-gap:20px;
 }
 
-.contact form label {
-  display: block;
+.contact form label{
+  display:block;
 }
 
-.contact form p {
-  margin: 0;
+.contact form p{
+  margin:0;
 }
 
-.contact form .full {
+.contact form .full{
   grid-column: 1 / 3;
 }
 
-.contact form button,
-.contact form input,
-.contact form textarea {
-  width: 100%;
-  padding: 1em;
-  border: 1px solid #c9e6ff;
+.contact form button, .contact form input, .contact form textarea{
+  width:100%;
+  padding:1em;
+  border:1px solid #c9e6ff;
 }
 
-.contact form button {
-  background: #c9e6ff;
-  border: 0;
+.contact form button{
+  background:#c9e6ff;
+  border:0;
   text-transform: uppercase;
 }
 
-.contact form button:hover,
-.contact form button:focus {
-  background: #92bde7;
-  color: #fff;
-  outline: 0;
+.contact form button:hover,.contact form button:focus{
+  background:#92bde7;
+  color:#fff;
+  outline:0;
   transition: background-color 2s ease-out;
 }
 
 /* LARGE SCREENS */
-@media (min-width: 700px) {
-  .wrapper {
+@media(min-width:700px){
+  .wrapper{
     display: grid;
     grid-template-columns: 1fr 2fr;
   }
 
-  .wrapper > * {
-    padding: 2em;
+  .wrapper > *{
+    padding:2em;
   }
 
-  .company-info h3,
-  .company-info ul,
-  .brand {
+  .company-info h3, .company-info ul, .brand{
     text-align: left;
   }
 }


### PR DESCRIPTION
When I cloned the original code, I found an error that **exphbs** is not a function. I rewrite the code with `require("express-handlebars").engine({parameters})` which solved the issue. For a better scenario, I am putting the latest versions of npm packages. Your old version was right but as per **express-handlebars** documentation, I think you need to change the code.